### PR TITLE
Added flake.nix file for NixOS users to run Riko

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ uv pip install -r requirements.txt
 * CUDA & cuDNN installed correctly (for Faster-Whisper GPU support)
 * `ffmpeg` installed (for audio processing)
 
+## Alternative NixOS Install using Flakes
+
+```bash
+cd ~/riko_project
+nix develop
+```
 
 ## 🧪 Usage
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "DevShell for Riko Project";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  };
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs {
+      inherit system;
+      config = {
+        allowUnfreePredicate = pkg: builtins.elem (pkgs.lib.getName pkg) [ "nvidia-x11" ];
+      };
+    };
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      name = "riko-devshell";
+
+      buildInputs = [
+        pkgs.python310
+        pkgs.ffmpeg_6
+        pkgs.portaudio
+        pkgs.git
+        pkgs.linuxPackages.nvidia_x11
+      ];
+
+      shellHook = ''
+        echo "Welcome to Riko DevShell!"
+        export VENV_DIR=$PWD/.venv
+        export UV_PYTHON=$VENV_DIR/bin/python
+
+        # Create venv if it doesn't exist
+        if [ ! -d "$VENV_DIR" ]; then
+          echo "Creating Python virtual environment..."
+          ${pkgs.python310}/bin/python3 -m venv $VENV_DIR
+        fi
+
+        # Activate venv
+        . $VENV_DIR/bin/activate
+
+        # Install Python dependencies if not already installed
+        if [ ! -f "$VENV_DIR/.requirements_installed" ]; then
+          echo "Installing Python dependencies..."
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r extra-req.txt
+          touch $VENV_DIR/.requirements_installed
+        fi
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Nix is a reproducible declarative OS. While packaging can be quite difficult (I vibe coded the flake using ChatGPT) using flakes that have been created already is quite easy from the user side. No worrying about python version control (the flake specifies what version of python to use) no worrying about pip versions (the flake specifies that). Just one command and it all installs.